### PR TITLE
handle SSR module generation totally in-memory

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -3,7 +3,6 @@ const path = require('path')
 const url = require('url')
 
 const defaultOptions = {
-  cacheDir: '.cache/svelte',
   assetDir: 'assets',
   outputClient: true,
   rollupPluginSvelteSSROptions: {},
@@ -60,7 +59,7 @@ module.exports = function (eleventyConfig, configOptions = {}) {
       await eleventySvelte.build(this.config.dir.output, this.config.pathPrefix)
     },
     getInstanceFromInputPath: function (inputPath) {
-      return eleventySvelte.getComponent(path.normalize(inputPath)).ssr
+      return eleventySvelte.getComponent(path.normalize(inputPath))
     },
     compile: function (str, inputPath) {
       return (data) => {
@@ -68,7 +67,7 @@ module.exports = function (eleventyConfig, configOptions = {}) {
           // When str has a value, it's being used for permalinks in data
           return typeof str === 'function' ? str(data) : str
         }
-        return eleventySvelte.getComponent(path.normalize(inputPath)).ssr.default.render(data).html
+        return eleventySvelte.getComponent(path.normalize(inputPath)).ssr.render(data).html
       }
     },
   })


### PR DESCRIPTION
Ok, so the explanation for this one goes as follows:

It bothered me slightly that a 'cache' directory was necessary for the output of the SSR module. Since this module is generated and used immediately to render the output files, I thought it would be nice for all this to happen in-memory, without the need to pollute the users workspace with unnecessary build artifacts.

This PR swaps `rollup.write()` for the `rollup.generate()` method during the SSR module generation. In order to ensure that rollup generates a single code chunk for each `*.11ty.svelte` input file, I had to run `rollup.rollup()` _seperately_ for each input, instead of passing in an array of inputs.

As for the method I used to require a module from a string, I got that from this [oldy-but-goody stackoverflow](https://stackoverflow.com/questions/17581830/load-node-js-module-from-string-in-memory). The age of this post shows that the mechanism I used has been supported for a long time in Node - which implies it will remain supported for a long time.