### PR TITLE
Support for <svelte:head> in SSR rendered output

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -75,7 +75,16 @@ module.exports = function (eleventyConfig, configOptions = {}) {
           // When str has a value, it's being used for permalinks in data
           return typeof str === 'function' ? str(data) : str
         }
-        return eleventySvelte.getComponent(path.normalize(inputPath)).ssr.render(data).html
+
+        const {
+          html,
+          head
+        } = eleventySvelte.getComponent(path.normalize(inputPath)).ssr.render(data);
+
+        return {
+          html,
+          head
+        }
       }
     },
   })

--- a/example/_includes/layouts/main.njk
+++ b/example/_includes/layouts/main.njk
@@ -4,10 +4,12 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{{ title }}</title>
+  
+    {{ content.head | safe }}
   </head>
   <body>
     <div id="app">
-      {{ content | safe }}
+      {{ content.html | safe }}
     </div>
   </body>
   <script>

--- a/example/index.11ty.svelte
+++ b/example/index.11ty.svelte
@@ -1,3 +1,7 @@
+<svelte:head>
+  <meta name="description" content="Website about possums">
+</svelte:head>
+
 <script context="module">
   export const data = () => {
     return {


### PR DESCRIPTION
A starting point for implementing #6 .

The anonymous function returned in `compile()` no longer returns the html as string, so this might break something as the function signature changes - it can now return `str`, `str(data)` or an object `{ html, head }`.

Due to my poor knowledge of 11ty,  I'm not entirely sure what the lines 74-76 are for, so please take that into consideration.
